### PR TITLE
Benchmarks for Encode, Decode and DecodeConfig

### DIFF
--- a/decode_test.go
+++ b/decode_test.go
@@ -99,3 +99,15 @@ func TestDecodeRejectsTruncatedData(t *testing.T) {
 		t.Errorf("expected ErrUnexpectedEOF error, got %v", err)
 	}
 }
+
+func BenchmarkDecodeConfig(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		DecodeConfig(bytes.NewReader(imageData))
+	}
+}
+
+func BenchmarkDecode(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		Decode(bytes.NewReader(imageData))
+	}
+}

--- a/encode_test.go
+++ b/encode_test.go
@@ -3,6 +3,8 @@ package imagefile
 import (
 	"bytes"
 	"image"
+	"image/draw"
+	"io/ioutil"
 	"testing"
 )
 
@@ -41,5 +43,24 @@ func TestEncode64(t *testing.T) {
 
 	if !bytes.Equal(imageData, buf.Bytes()) {
 		t.Fatal("encoding error")
+	}
+}
+
+func BenchmarkEncode(b *testing.B) {
+	m := image.NewRGBA(image.Rect(0, 0, 1000, 1000))
+
+	draw.Draw(m, m.Bounds(), &image.Uniform{green}, image.ZP, draw.Src)
+
+	m.Set(0, 0, red)
+	m.Set(0, 10, blue)
+	m.Set(100, 10, red)
+	m.Set(600, 100, blue)
+	m.Set(201, 20, blue)
+	m.Set(12, 25, red)
+
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		Encode(ioutil.Discard, m)
 	}
 }


### PR DESCRIPTION
### Results when running on a MacBook Air (11-inch, Mid 2013)
 - OS X El Capitan (10.11) 
 - 1,7 GHz Intel Core i7
 - 8 GB 1600 MHz DDR3

```sh
$ go test -bench=. -benchmem -benchtime=10s | pb ns

+------------------+-------------+-------+------+----------------+
| Name             |        Runs | ns/op | B/op | allocations/op |
+------------------+-------------+-------+------+----------------+
| Decode           |  50,000,000 |   329 |  192 |              4 |
+------------------+-------------+-------+------+----------------+
| DecodeConfig     | 100,000,000 |   158 |   80 |              2 |
+------------------+-------------+-------+------+----------------+
| Encode           | 100,000,000 |   105 |   32 |              1 |
+------------------+-------------+-------+------+----------------+


Summary:
+------+
PASS
ok  	github.com/mehlon/imagefile	43.421s
```