### PR TITLE
Replaced ErrNoMagic with FormatError

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -2,15 +2,19 @@ package imagefile
 
 import (
 	"encoding/binary"
-	"errors"
 	"image"
 	"image/color"
 	"io"
 )
 
-// ErrNoMagic is returned by Decode and DecodeConfig when the image header
+// A FormatError reports that the input is not a valid Imagefile.
+// It is returned by Decode and DecodeConfig when the image header
 // doesn't start with "imagefile".
-var ErrNoMagic = errors.New("no magic")
+type FormatError string
+
+func (e FormatError) Error() string {
+	return "invalid Imagefile format: " + string(e)
+}
 
 func decodeConfig(r io.Reader) (int, int, error) {
 	header := make([]byte, 9+4+4)
@@ -20,7 +24,7 @@ func decodeConfig(r io.Reader) (int, int, error) {
 	}
 
 	if string(header[:9]) != "imagefile" {
-		return 0, 0, ErrNoMagic
+		return 0, 0, FormatError("unexpected magic number")
 	}
 
 	w := binary.BigEndian.Uint32(header[9:])

--- a/decode_test.go
+++ b/decode_test.go
@@ -26,8 +26,8 @@ func TestDecodeConfig(t *testing.T) {
 
 func TestDecodeConfigRejectsInvalidMagic(t *testing.T) {
 	_, err := DecodeConfig(strings.NewReader("imagefil\xff\x00\x00\x00\x03\x00\x00\x00\x03"))
-	if err != ErrNoMagic {
-		t.Errorf("expected ErrNoMagic error, got %v", err)
+	if _, ok := err.(FormatError); !ok {
+		t.Errorf("expected FormatError error, got %v", err)
 	}
 }
 
@@ -83,8 +83,8 @@ func TestDecode(t *testing.T) {
 
 func TestDecodeRejectsInvalidMagic(t *testing.T) {
 	_, err := Decode(strings.NewReader("imagefil\xff\x00\x00\x00\x01\x00\x00\x00\x01\x00\x00\x00\x00"))
-	if err != ErrNoMagic {
-		t.Errorf("expected ErrNoMagic error, got %v", err)
+	if _, ok := err.(FormatError); !ok {
+		t.Errorf("expected FormatError error, got %v", err)
 	}
 }
 


### PR DESCRIPTION
The `FormatError` type is used to match the [jpeg](https://golang.org/pkg/image/jpeg/#FormatError) and [png](https://golang.org/pkg/image/png/#FormatError) packages.